### PR TITLE
Add WebSocket client integration test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
+# Realtime RAG Prototype
 
+This repository contains a minimal FastAPI-based WebSocket backend that accepts
+real-time ASR text chunks, performs a lightweight question detection heuristic,
+and returns a mocked Retrieval-Augmented Generation (RAG) answer when a
+question-like utterance is detected.
+
+## Features
+
+- WebSocket endpoint at `/ws/realtime-asr` for streaming ASR chunks.
+- Simple in-memory session state to accumulate final ASR segments.
+- Heuristic question detection (punctuation and keyword based).
+- Mocked RAG call that demonstrates the expected status/answer flow.
+- Basic control commands (`pause`, `resume`, `stop`).
+
+## Getting Started
+
+1. **Install dependencies** (preferably inside a virtual environment):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Run the service**:
+
+   ```bash
+   uvicorn app.main:app --host 0.0.0.0 --port 8000
+   ```
+
+3. **Run the included test client** (optional):
+
+   ```bash
+   python scripts/ws_client.py --uri ws://localhost:8000/ws/realtime-asr
+   ```
+
+   The script replays a small sequence of ASR chunks and prints the
+   server's responses so you can observe the end-to-end flow.
+
+4. **Test with `websocat` or similar**:
+
+   ```bash
+   websocat ws://localhost:8000/ws/realtime-asr
+   ```
+
+   Example payloads:
+
+   ```json
+   {"type": "asr_chunk", "text": "你好，请问库存情况怎么样", "is_final": true}
+   ```
+
+   ```json
+   {"type": "control", "action": "pause"}
+   ```
+
+The current implementation uses a mock RAG response. Integrate your preferred
+LLM/RAG provider inside `run_mock_rag` in `app/main.py` when ready.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,200 @@
+"""Minimal realtime RAG WebSocket prototype."""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Dict, List
+from uuid import uuid4
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+app = FastAPI(title="Realtime RAG Prototype")
+
+
+class SessionState:
+    """Track per-connection conversation state."""
+
+    QUESTION_HINTS = {"?", "吗", "呢", "怎么", "为何", "为什么", "请问", "多少", "哪", "怎么做"}
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self.final_chunks: List[str] = []
+        self.is_paused: bool = False
+
+    def add_chunk(self, text: str, is_final: bool) -> None:
+        if is_final:
+            self.final_chunks.append(text.strip())
+
+    @property
+    def aggregated_text(self) -> str:
+        return " ".join(chunk for chunk in self.final_chunks if chunk)
+
+    def reset(self) -> None:
+        self.final_chunks.clear()
+
+    def looks_like_question(self) -> bool:
+        text = self.aggregated_text
+        if not text:
+            return False
+        lowered = text.lower()
+        if any(token in lowered for token in ("what", "why", "how", "when", "where", "?")):
+            return True
+        return any(hint in text for hint in self.QUESTION_HINTS)
+
+
+async def run_mock_rag(query: str) -> str:
+    """Simulate a RAG backend response."""
+    await asyncio.sleep(0.1)
+    return (
+        "这是一个模拟回答，用于展示系统流程。"\
+        f" 根据你的问题“{query}”，建议稍后接入真正的 RAG 服务。"
+    )
+
+
+def stream_answer(answer: str, max_chunk_size: int = 120) -> List[str]:
+    """Split long answers into smaller chunks for streaming."""
+    chunks: List[str] = []
+    current = []
+    current_len = 0
+    for part in answer.split():
+        part_len = len(part) + 1  # include space
+        if current_len + part_len > max_chunk_size and current:
+            chunks.append(" ".join(current))
+            current = [part]
+            current_len = len(part)
+        else:
+            current.append(part)
+            current_len += part_len
+    if current:
+        chunks.append(" ".join(current))
+    if not chunks:
+        chunks.append(answer)
+    return chunks
+
+
+@app.websocket("/ws/realtime-asr")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept()
+    session = SessionState(session_id=str(uuid4()))
+    await websocket.send_json({"type": "ack", "message": "connected", "session_id": session.session_id})
+    await websocket.send_json({"type": "status", "stage": "listening"})
+
+    try:
+        while True:
+            message = await websocket.receive_text()
+            try:
+                payload: Dict[str, object] = json.loads(message)
+            except json.JSONDecodeError:
+                await websocket.send_json({
+                    "type": "error",
+                    "code": "INVALID_JSON",
+                    "message": "Payload must be valid JSON text.",
+                })
+                continue
+
+            msg_type = payload.get("type")
+            if not isinstance(msg_type, str):
+                await websocket.send_json({
+                    "type": "error",
+                    "code": "INVALID_MESSAGE",
+                    "message": "Missing or invalid 'type' field.",
+                })
+                continue
+
+            await websocket.send_json({
+                "type": "ack",
+                "received_type": msg_type,
+                "session_id": session.session_id,
+            })
+
+            if msg_type == "keepalive":
+                continue
+
+            if msg_type == "control":
+                action = payload.get("action")
+                if action == "pause":
+                    session.is_paused = True
+                    await websocket.send_json({"type": "status", "stage": "paused"})
+                elif action == "resume":
+                    session.is_paused = False
+                    await websocket.send_json({"type": "status", "stage": "listening"})
+                elif action == "stop":
+                    await websocket.send_json({"type": "status", "stage": "closed"})
+                    break
+                else:
+                    await websocket.send_json({
+                        "type": "error",
+                        "code": "UNKNOWN_ACTION",
+                        "message": "Supported actions: pause, resume, stop.",
+                    })
+                continue
+
+            if msg_type != "asr_chunk":
+                await websocket.send_json({
+                    "type": "error",
+                    "code": "UNSUPPORTED_TYPE",
+                    "message": "Expected message type 'asr_chunk'.",
+                })
+                continue
+
+            if session.is_paused:
+                await websocket.send_json({
+                    "type": "status",
+                    "stage": "paused",
+                    "note": "Chunk received while paused; ignoring.",
+                })
+                continue
+
+            text = payload.get("text")
+            is_final = payload.get("is_final", False)
+            if not isinstance(text, str):
+                await websocket.send_json({
+                    "type": "error",
+                    "code": "INVALID_MESSAGE",
+                    "message": "'text' field must be a string.",
+                })
+                continue
+            if not isinstance(is_final, bool):
+                await websocket.send_json({
+                    "type": "error",
+                    "code": "INVALID_MESSAGE",
+                    "message": "'is_final' field must be a boolean.",
+                })
+                continue
+
+            session.add_chunk(text, is_final=is_final)
+
+            if not is_final:
+                continue
+
+            if not session.looks_like_question():
+                await websocket.send_json({
+                    "type": "status",
+                    "stage": "waiting_for_question",
+                    "note": "No question detected in final chunk.",
+                })
+                continue
+
+            question = session.aggregated_text
+            await websocket.send_json({"type": "status", "stage": "analyzing", "question": question})
+            await websocket.send_json({"type": "status", "stage": "querying_rag"})
+
+            answer = await run_mock_rag(question)
+            chunks = stream_answer(answer)
+            for idx, chunk in enumerate(chunks):
+                await websocket.send_json({
+                    "type": "answer",
+                    "stream_index": idx,
+                    "content": chunk,
+                    "final": idx == len(chunks) - 1,
+                })
+            await websocket.send_json({"type": "status", "stage": "idle"})
+            session.reset()
+    except WebSocketDisconnect:
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch helper
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+websockets==12.0

--- a/scripts/ws_client.py
+++ b/scripts/ws_client.py
@@ -1,0 +1,99 @@
+"""Simple WebSocket client for manual integration testing.
+
+This script connects to the realtime RAG WebSocket backend, replays a
+predefined sequence of ASR chunks, and prints every message received from the
+server. It helps validate the end-to-end flow without requiring a custom UI.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import websockets
+
+
+@dataclass
+class AsrChunk:
+    """Representation of a single ASR chunk to send to the backend."""
+
+    text: str
+    is_final: bool = True
+    timestamp_ms: int | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "type": "asr_chunk",
+            "text": self.text,
+            "is_final": self.is_final,
+        }
+        if self.timestamp_ms is not None:
+            payload["timestamp"] = self.timestamp_ms
+        return payload
+
+
+async def _send_sequence(ws: websockets.WebSocketClientProtocol, chunks: Iterable[AsrChunk]) -> None:
+    """Send ASR chunks with small pauses to emulate streaming input."""
+
+    for chunk in chunks:
+        await ws.send(json.dumps(chunk.to_payload(), ensure_ascii=False))
+        await asyncio.sleep(0.1)
+
+    # Gracefully stop the session so the server can clean up state.
+    await ws.send(json.dumps({"type": "control", "action": "stop"}))
+
+
+async def _reader(ws: websockets.WebSocketClientProtocol) -> None:
+    """Continuously print responses until the connection closes."""
+
+    try:
+        async for message in ws:
+            print("<-", message)
+    except websockets.ConnectionClosedOK:
+        print("Connection closed by server.")
+    except websockets.ConnectionClosedError as exc:  # pragma: no cover - depends on runtime
+        print(f"Connection closed with error: {exc}")
+
+
+def _build_default_sequence() -> List[AsrChunk]:
+    """Create a short scenario that should trigger a mock RAG answer."""
+
+    return [
+        AsrChunk(text="大家好，今天我们复盘一下发布进展。"),
+        AsrChunk(text="目前后台服务已经部署完成。"),
+        AsrChunk(text="请问接下来要怎么安排推送上线？"),
+    ]
+
+
+async def run_client(uri: str, sequence: Iterable[AsrChunk]) -> None:
+    """Run the client by connecting, launching the reader, and replaying chunks."""
+
+    async with websockets.connect(uri) as ws:
+        reader_task = asyncio.create_task(_reader(ws))
+        await _send_sequence(ws, sequence)
+        await reader_task
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Test client for realtime RAG WebSocket service")
+    parser.add_argument(
+        "--uri",
+        default="ws://127.0.0.1:8000/ws/realtime-asr",
+        help="WebSocket endpoint to connect to (default: %(default)s)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    sequence = _build_default_sequence()
+    try:
+        asyncio.run(run_client(args.uri, sequence))
+    except KeyboardInterrupt:  # pragma: no cover - user initiated
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a FastAPI WebSocket endpoint that accumulates ASR chunks and streams a mock RAG reply when a question is detected
- include simple session handling, control commands, and heuristics for question detection
- document setup steps and dependencies for running the prototype service
- add a Python WebSocket client script for manual integration testing and document how to use it

## Testing
- python -m compileall app scripts

------
https://chatgpt.com/codex/tasks/task_e_68d8a6d50298832bae3d098e02188cd3